### PR TITLE
Sl90 support

### DIFF
--- a/Database/lights.json
+++ b/Database/lights.json
@@ -1257,6 +1257,23 @@
                 "power": "{cmdtag} {powertag} {size} {state:uint8:enum(1=on,2=off)} {checksum}",
                 "cct": "{cmdtag} {ccttag} {size} {brr:uint8:range(0,100)} {cct:uint8:range(27,65)} 0x32 0x00 0x00 {checksum}"
             }
+        },
+        {
+            "type": 71,
+            "name": "Neewer SL90",
+            "image": "https://github.com/keefo/NeewerLite/blob/main/Database/light_images/sl90-pro.png?raw=true",
+            "link": "https://neewer.com/products/neewer-sl90-rgb-led-video-light",
+            "supportRGB": true,
+            "supportCCTGM": true,
+            "supportMusic": true,
+            "support17FX": true,
+            "support9FX": false,
+            "cctRange": {
+                "min": 25,
+                "max": 100
+            },
+            "newPowerLightCommand": true,
+            "newRGBLightCommand": true
         }
     ]
 }

--- a/NeewerLite/NeewerLite/Model/NeewerLightConstant.swift
+++ b/NeewerLite/NeewerLite/Model/NeewerLightConstant.swift
@@ -170,6 +170,9 @@ class NeewerLightConstant {
                 return "RGB1"
             case "20200037":
                 return "SL90"
+            case "20240073":
+                // Newer SL90 variant using the newer "Infinity" protocol
+                return "SL90"
             case "20200049":
                 return "RGB1200"
             case "20210006":
@@ -348,7 +351,7 @@ class NeewerLightConstant {
         // Some newer SL90 variants ("Infinity" protocol) are renamed by the app to "SL90-...",
         // which can cause nickname-based matching to fail. Detect via the raw BLE name instead.
         // Ref: https://github.com/keefo/NeewerLite/issues/94
-        if rawname.hasPrefix("NW-202040073") || rawname.hasPrefix("NW-20200037") {
+        if rawname.hasPrefix("NW-20240073") || rawname.hasPrefix("NW-20200037") {
             return 71
         }
 

--- a/NeewerLite/NeewerLite/Model/NeewerLightConstant.swift
+++ b/NeewerLite/NeewerLite/Model/NeewerLightConstant.swift
@@ -141,6 +141,8 @@ class NeewerLightConstant {
                 return "Q200"
             case 69:
                 return "TL21C"
+            case 71:
+                return "SL90"
             case 73:
                 return "MS150C"
             case 74:
@@ -342,6 +344,14 @@ class NeewerLightConstant {
         // what does these light types means?
         // Not sure.
         var lightType: UInt8 = 8
+
+        // Some newer SL90 variants ("Infinity" protocol) are renamed by the app to "SL90-...",
+        // which can cause nickname-based matching to fail. Detect via the raw BLE name instead.
+        // Ref: https://github.com/keefo/NeewerLite/issues/94
+        if rawname.hasPrefix("NW-202040073") || rawname.hasPrefix("NW-20200037") {
+            return 71
+        }
+
         if nickName.contains("SRP") || nickName.contains("RP18-P") {
             lightType = 1
             return lightType

--- a/NeewerLite/NeewerLiteTests/NeewerLiteTests.swift
+++ b/NeewerLite/NeewerLiteTests/NeewerLiteTests.swift
@@ -145,6 +145,11 @@ class NeewerLiteTests: XCTestCase {
         XCTAssertEqual(name.nickName, "CB60B-E4B053")
         XCTAssertEqual(name.projectName, "CB60B")
         XCTAssertEqual(NeewerLightConstant.getLightType(nickName: name.nickName, rawname: "", projectName: name.projectName), 31, "")
+        
+        name = NeewerLightConstant.getLightNames(rawName: "NW-20240073&00000000", identifier: "FCCD4ADF-1AD1-72B7-485D-39061E3686F0")
+        XCTAssertEqual(name.nickName, "SL90-3686F0")
+        XCTAssertEqual(name.projectName, "SL90")
+        XCTAssertEqual(NeewerLightConstant.getLightType(nickName: name.nickName, rawname: "NW-20240073&00000000", projectName: name.projectName), 71, "")
     }
 
     func test_fxCommand() throws {


### PR DESCRIPTION
Hi I hope I did all correct: 

Registered SL90 in the lights database and map type 71 to "SL90". Improve device detection for newer SL90 variants by matching the raw BLE name to avoid nickname-based mismatches. wrote a test... It works for my SL90.. not sure if they have different series

Refs: #94